### PR TITLE
AR is left undefined, added hard definition.

### DIFF
--- a/Makefile.gcc
+++ b/Makefile.gcc
@@ -9,6 +9,7 @@ PREFIX = $(TOOLCHAIN_ROOT)/bin/msp430-elf-
 CC      = $(PREFIX)gcc
 LD      = $(PREFIX)gcc
 AS      = $(PREFIX)as
+AR      = $(PREFIX)ar
 GDB     = $(PREFIX)gdb
 
 LIB_SUFFIX = a


### PR DESCRIPTION
Without this defined; edb-rat can't be built on Mac OSX.
