### PR TITLE
add the path to the msp430-elf-ar

### DIFF
--- a/Makefile.gcc
+++ b/Makefile.gcc
@@ -8,6 +8,7 @@ CC      = $(PREFIX)gcc
 LD      = $(PREFIX)gcc
 AS      = $(PREFIX)as
 GDB     = $(PREFIX)gdb
+AR	= $(PREFIX)ar
 
 include $(MAKER_ROOT)/Makefile.version
 


### PR DESCRIPTION
the path to the msp430-elf-ar is missing. This it causes a problem if you try to build the libraries on mac os 